### PR TITLE
as/google tag manager fix

### DIFF
--- a/server/init.coffee
+++ b/server/init.coffee
@@ -18,7 +18,7 @@ if Meteor.settings.GTM #if there is a Google Tag Manager key in the settings, in
             new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
             j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer'," + Meteor.settings.GTM + ");</script>"
+    })(window,document,'script','dataLayer', '" + Meteor.settings.GTM + "');</script>"
 
     Inject.rawBody('googleTagManagerScript', googleTagManagerScript)
 


### PR DESCRIPTION
I realised that I forgot to add some quotes around the Meteor.settings.GTM variable.
